### PR TITLE
fix "Unable to process file" with paths that have a space

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -14,7 +14,7 @@ function activate(context)
 			{
 				let command = config.path + ' ';
 				if (config.args) command += config.args;
-				command += ' ' + path;
+				command += ' \"' + path + '\"';
 				child.exec(command, (error, out, errstr) => {
 					if (error) {
 						vscode.window.showErrorMessage('astyle-format error: ' + errstr);

--- a/extension.js
+++ b/extension.js
@@ -1,13 +1,17 @@
 const vscode = require('vscode');
 const child = require('child_process');
 
-function activate(context) {
-	let disposable = vscode.commands.registerCommand('astyle-format.format', function () {
+function activate(context) 
+{
+	let disposable = vscode.commands.registerCommand('astyle-format.format', function() 
+	{
 		const config = vscode.workspace.getConfiguration('astyle-format'),
 		    file = vscode.window.activeTextEditor.document,
 			path = file.fileName;
+
 		file.save().then(() => {
-			if (config.path) {
+			if (config.path) 
+			{
 				let command = config.path + ' ';
 				if (config.args) command += config.args;
 				command += ' ' + path;
@@ -16,7 +20,9 @@ function activate(context) {
 						vscode.window.showErrorMessage('astyle-format error: ' + errstr);
 					}
 				});
-			} else {
+			} 
+			else 
+			{
 				vscode.window.showErrorMessage('astyle-format error: No path specified.')
 			}
 		});


### PR DESCRIPTION
ex: `"C:\Epic Files\hehe.gsc"` would only be processed as `"C:\Epic "` and wouldn't work