### PR TITLE
Add AStyle to builtin formatters / activate on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,17 @@ Astyle can be found at http://astyle.sourceforge.net/.
 
 ## Use
 
-Select 'Astyle Format Document' from the Command Palette or use the default provided keybinding  __CTRL+ALT+L__.
+There three ways to use this extension:
+1. Run the command 'Astyle Format Document' from the Command Palette (F1)
+2. Use the default provided keybinding  __CTRL+ALT+L__, which is shortcut for 'Astyle Format Document' command
+3. Use builtin format function command __ALT+SHIFT+F__ and/or select 'Astyle' from the list of formatters. 
 
 ## Configuration
 
 This extension contributes the following settings:
 
-* `astyle-format.path`: path to astyle executable
+* `astyle-format.path`: path to astyle executable. \
+**(OPTIONAL)**. __If not set, the extension will attempt to find astyle in the system PATH.__
 * `astyle-format.args`: arguments passed to astyle
 
 ## Note

--- a/extension.js
+++ b/extension.js
@@ -1,8 +1,11 @@
 const vscode = require('vscode');
 const child = require('child_process');
 
+const COMMAND_FORMAT = "astyle-format.format"; // keep same as in package.json
+
 function activate(context) {
-    let disposable = vscode.commands.registerCommand('astyle-format.format', function() {
+    
+    let disposable = vscode.commands.registerCommand(COMMAND_FORMAT, function() {
         const config = vscode.workspace.getConfiguration('astyle-format'),
             file = vscode.window.activeTextEditor.document,
             path = file.fileName;
@@ -22,6 +25,18 @@ function activate(context) {
             }
         });
     });
+
+    vscode.languages.getLanguages().then(list => {
+        for(const language of list){
+            vscode.languages.registerDocumentFormattingEditProvider(language, {
+                provideDocumentFormattingEdits(document){
+                    vscode.commands.executeCommand(COMMAND_FORMAT);
+                    return [];
+                }
+            });
+        }
+    });
+
     context.subscriptions.push(disposable);
 }
 

--- a/extension.js
+++ b/extension.js
@@ -5,7 +5,7 @@ const COMMAND_FORMAT = "astyle-format.format"; // keep same as in package.json
 
 function activate(context) {
     
-    let disposable = vscode.commands.registerCommand(COMMAND_FORMAT, function() {
+    const disposable = vscode.commands.registerCommand(COMMAND_FORMAT, function() {
         const config = vscode.workspace.getConfiguration('astyle-format'),
             file = vscode.window.activeTextEditor.document,
             path = file.fileName;
@@ -28,12 +28,13 @@ function activate(context) {
 
     vscode.languages.getLanguages().then(list => {
         for(const language of list){
-            vscode.languages.registerDocumentFormattingEditProvider(language, {
+            const disposable = vscode.languages.registerDocumentFormattingEditProvider(language, {
                 provideDocumentFormattingEdits(document){
                     vscode.commands.executeCommand(COMMAND_FORMAT);
                     return [];
                 }
             });
+            context.subscriptions.push(disposable);
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
 			"title": "astyle-format config",
 			"properties": {
 				"astyle-format.path": {
-				"type": "string",
-				"default": null,
-				"description": "path to astyle executable"
+					"type": "string",
+					"default": null,
+					"description": "path to astyle executable"
 				},
 				"astyle-format.args": {
-				"type": "string",
-				"default": null,
-				"description": "arguments passed to astyle"
+					"type": "string",
+					"default": null,
+					"description": "arguments passed to astyle"
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCommand:astyle-format.format"
+		"onStartupFinished"
 	],
 	"main": "./extension.js",
 	"contributes": {


### PR DESCRIPTION
AStyle can now be used as builtin vscode function "format document". May be useful or just comfortable if you're used to it. 
Also added auto startup just in case and feature to lookup for asyle binary in PATH
 